### PR TITLE
Change url check and add filter

### DIFF
--- a/cmd/check_goversion/main.go
+++ b/cmd/check_goversion/main.go
@@ -23,7 +23,7 @@ func main() {
 	p.StringFlag("endpoint", "", "The page to check for your application's Go version. The page must output JSON.")
 	p.StringFlag("endpoint-path", "", "The path to the JSON key containing your application's Go version specified in JavaScript notation")
 	p.StringFlag("version", "latest", "The expected version. If set to `latest`, the latest-version-url will be consulted")
-	p.StringFlag("version-filter", "go1.10", "A prefix filter for the version.  Example `go1.10`")
+	p.StringFlag("latest-version-filter", "go1.10", "A prefix filter for the version.  Example `go1.10`")
 	p.StringFlag("latest-version-url", "https://golang.org/dl/?mode=json", "The url where one can retrieve the latest version of Go")
 	p.StringFlag("tls-client-cert", "", "path to certificate file used to connect to endpoint")
 	p.StringFlag("tls-client-key", "", "path to private key file used to connect to endpoint")
@@ -54,7 +54,7 @@ func main() {
 
 	if version == "latest" {
 		latestVersionURL, _ := p.OptString("latest-version-url")
-		filterVersion, _ := p.OptString("version-filter")
+		filterVersion, _ := p.OptString("latest-version-filter")
 		version, err = fetchGoVersion(latestVersionURL, filterVersion)
 		if err != nil {
 			p.Fatal(errors.Wrap(err, "fetching latest go version"))

--- a/cmd/check_goversion/main.go
+++ b/cmd/check_goversion/main.go
@@ -64,8 +64,8 @@ func main() {
 	code := nagios.OK
 	label := "OK"
 	if appVersion != version {
-		code = nagios.CRITICAL
-		label = "CRITICAL"
+		code = nagios.WARNING
+		label = "WARNING"
 	}
 
 	p.Exit(code, fmt.Sprintf("%s - application_version=%q expected_version=%q", label, appVersion, version))

--- a/cmd/check_goversion/main_test.go
+++ b/cmd/check_goversion/main_test.go
@@ -50,7 +50,7 @@ func TestFetchGoVersion(t *testing.T) {
 	s := httptest.NewServer(hler)
 	defer s.Close()
 
-	version, err := fetchGoVersion(s.URL)
+	version, err := fetchGoVersion(s.URL, "go1.10")
 	is.NoErr(err)
 	is.Equal(version, "go1.10.3")
 }


### PR DESCRIPTION
Currently `https://golang.org/VERSION?m=text` only shows go1.11. I found we can get the download page in json which shows the latest stable release. `https://golang.org/dl/?mode=json` So I added a that we can filter on the version to get the latest go1.10 release number.

Just tested it on staging.
```
$ check_goversion -endpoint https://staging.cust.graymeta.com/healthz -endpoint-path app.metadata.go_version
CRITICAL - application_version="go1.10.6" expected_version="go1.10.7"
```